### PR TITLE
feat: Enable retrieving regions from a list

### DIFF
--- a/pkg/cli/run.go
+++ b/pkg/cli/run.go
@@ -15,7 +15,7 @@ func (runner *Runner) execute(ctx *cli.Context) error {
 	if region == "" {
 		region, err = controller.SelectRegion()
 		if err != nil {
-			return fmt.Errorf("faild to get region name: %w", err)
+			return fmt.Errorf("failed to get region name: %w", err)
 		}
 	}
 

--- a/pkg/cli/run.go
+++ b/pkg/cli/run.go
@@ -13,7 +13,7 @@ var err error
 func (runner *Runner) execute(ctx *cli.Context) error {
 	region := ctx.String("region")
 	if region == "" {
-		region, err = controller.PromptRegion()
+		region, err = controller.SelectRegion()
 		if err != nil {
 			return fmt.Errorf("faild to get region name: %w", err)
 		}

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -1,0 +1,9 @@
+package constants
+
+var (
+	AWS_VALID_REGIONS = []string{"us-east-1", "us-east-2", "us-west-1", "us-west-2", "af-south-1", "ap-east-1", "ap-south-2",
+		"ap-southeast-3", "ap-south-1", "ap-northeast-3", "ap-northeast-2", "ap-southeast-1", "ap-southeast-2",
+		"ap-northeast-1", "ca-central-1", "eu-central-1", "eu-west-1", "eu-west-2", "eu-south-1", "eu-west-3",
+		"eu-south-2", "eu-north-1", "eu-central-2", "me-south-1", "me-central-1", "sa-east-1", "us-gov-east-1",
+		"us-gov-west-1"}
+)

--- a/pkg/controller/profile.go
+++ b/pkg/controller/profile.go
@@ -1,6 +1,7 @@
 package controller
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/config"
@@ -23,7 +24,7 @@ func SelectProfile() (string, error) {
 	}
 	_, result, err := prompt.Run()
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("failed to select profile: %w", err)
 	}
 	return result, nil
 }

--- a/pkg/controller/region.go
+++ b/pkg/controller/region.go
@@ -1,15 +1,21 @@
 package controller
 
-import "github.com/manifoldco/promptui"
+import (
+	"github.com/Taiki130/ecsexec/pkg/constants"
+	"github.com/manifoldco/promptui"
+)
 
-func PromptRegion() (string, error) {
-	l := "Enter region"
-	prompt := promptui.Prompt{
+func SelectRegion() (string, error) {
+	l := "Select region"
+	prompt := promptui.Select{
 		Label: l,
+		Items: constants.AWS_VALID_REGIONS,
 	}
-	result, err := prompt.Run()
+
+	_, result, err := prompt.Run()
 	if err != nil {
 		return "", err
 	}
+
 	return result, nil
 }

--- a/pkg/controller/region.go
+++ b/pkg/controller/region.go
@@ -1,6 +1,9 @@
 package controller
 
 import (
+	"fmt"
+	"strings"
+
 	"github.com/Taiki130/ecsexec/pkg/constants"
 	"github.com/manifoldco/promptui"
 )
@@ -10,11 +13,14 @@ func SelectRegion() (string, error) {
 	prompt := promptui.Select{
 		Label: l,
 		Items: constants.AWS_VALID_REGIONS,
+		Searcher: func(input string, index int) bool {
+			return strings.Contains(strings.ToLower(constants.AWS_VALID_REGIONS[index]), strings.ToLower(input))
+		},
 	}
 
 	_, result, err := prompt.Run()
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("failed to select region: %w", err)
 	}
 
 	return result, nil


### PR DESCRIPTION
## **User description**
- resolves https://github.com/Taiki130/ecsexec/issues/15


___

## **Type**
Enhancement


___

## **Description**
- `pkg/cli/run.go`で、リージョン選択の関数を`controller.PromptRegion()`から`controller.SelectRegion()`に変更しました。
- `pkg/constants/constants.go`にAWSの有効なリージョンのリスト`AWS_VALID_REGIONS`を追加しました。
- `pkg/controller/region.go`で、リージョン選択のUIを改善し、`constants.AWS_VALID_REGIONS`を使用して有効なAWSリージョンから選択できるように変更しました。


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>run.go</strong><dd><code>リージョン選択機能の改善</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/cli/run.go
- `controller.PromptRegion()`を`controller.SelectRegion()`に変更しました。



</details>
    

  </td>
  <td><a href="https://github.com/Taiki130/ecsexec/pull/38/files#diff-47f2d9967f1f75f8c014037b08722883d56a0024589ba28a44842193fecf651b">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>constants.go</strong><dd><code>AWS有効リージョンのリスト追加</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/constants/constants.go
- AWSの有効なリージョンのリスト`AWS_VALID_REGIONS`を追加しました。



</details>
    

  </td>
  <td><a href="https://github.com/Taiki130/ecsexec/pull/38/files#diff-36043890c52c8201a8bc84238c219be45ce07bf172d89f693c7c54ffe70d046e">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>region.go</strong><dd><code>リージョン選択機能のUI改善と有効リージョンの選択</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/controller/region.go
<li><code>PromptRegion</code>関数を<code>SelectRegion</code>に変更し、リージョンを選択するUIを改善しました。<br> <li> <code>constants.AWS_VALID_REGIONS</code>を使用して、有効なAWSリージョンから選択できるようにしました。<br>


</details>
    

  </td>
  <td><a href="https://github.com/Taiki130/ecsexec/pull/38/files#diff-649f7eb932782c02b242c08145e8c48ef7d49eb014144e30e8d34640f7305d35">+11/-5</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

